### PR TITLE
Updated eslint-plugin-react extend

### DIFF
--- a/08 linter/README.md
+++ b/08 linter/README.md
@@ -169,7 +169,7 @@ _./.eslintrc.json_
 {
   "extends": [
     "eslint:recommended",
-    "eslint-plugin-react"
+    "plugin:react/recommended"
   ],
   "env": {
     "browser": true,


### PR DESCRIPTION
According to the documentation in https://www.npmjs.com/package/eslint-plugin-react, the preferred preset should be: "plugin:react/recommended"